### PR TITLE
SB-1353 Allow using `snapshot` keyword when converting a path to an Artifact

### DIFF
--- a/src/main/java/org/carlspring/maven/commons/util/PathParser.java
+++ b/src/main/java/org/carlspring/maven/commons/util/PathParser.java
@@ -88,10 +88,11 @@ public class PathParser
             version = segments.get(segments.size() - 2);
             String versionStripped = StringUtils.replaceIgnoreCase(version, "-snapshot", "");
 
-            // Character.isDigit is meant to handle corner cases such as "org/carlspring/strongbox/metadata/strongbox-metadata"
+            // corner cases - testConvertPathToArtifact#artifact16 and testConvertPathToArtifact#artifact30
             if (StringUtils.endsWithIgnoreCase(version, "-snapshot") ||
                 (StringUtils.containsIgnoreCase(filename, versionStripped) &&
-                 VERSION_PATTERN.matcher(version).matches())
+                 VERSION_PATTERN.matcher(version).matches()) ||
+                version.matches("\\d+")
             )
             {
                 groupId = segments.get(0);
@@ -121,7 +122,9 @@ public class PathParser
             {
                 // Maybe the path ends with the version?
                 version = segments.get(segments.size() - 1);
-                if (VERSION_PATTERN.matcher(version).matches())
+
+                // corner case - testConvertPathToArtifact#artifact31
+                if (VERSION_PATTERN.matcher(version).matches() || version.matches("\\d+"))
                 {
                     groupId = segments.stream()
                                       .limit(segments.size() - 2)

--- a/src/test/java/org/carlspring/maven/commons/utils/ArtifactUtilsTest.java
+++ b/src/test/java/org/carlspring/maven/commons/utils/ArtifactUtilsTest.java
@@ -357,6 +357,24 @@ public class ArtifactUtilsTest
         assertEquals("Failed to convert path to artifact!", "VER5.1-beta", artifact28.getVersion());
         assertEquals("Failed to convert path to artifact!", "javadoc", artifact28.getClassifier());
         assertEquals("Failed to covert path to artifact!", "jar", artifact28.getType());
+
+        Artifact artifact30 = ArtifactUtils.convertPathToArtifact("javax/inject/javax.inject/1/javax.inject-1.pom");
+
+        assertNotNull("Failed to covert path to artifact!", artifact30);
+        assertEquals("Failed to convert path to artifact!", "javax.inject", artifact30.getGroupId());
+        assertEquals("Failed to convert path to artifact!", "javax.inject", artifact30.getArtifactId());
+        assertEquals("Failed to convert path to artifact!", "1", artifact30.getVersion());
+        assertNull("Failed to convert path to artifact!", artifact30.getClassifier());
+        assertEquals("Failed to covert path to artifact!", "pom", artifact30.getType());
+
+        Artifact artifact31 = ArtifactUtils.convertPathToArtifact("javax/inject/javax.inject/1");
+
+        assertNotNull("Failed to covert path to artifact!", artifact31);
+        assertEquals("Failed to convert path to artifact!", "javax.inject", artifact31.getGroupId());
+        assertEquals("Failed to convert path to artifact!", "javax.inject", artifact31.getArtifactId());
+        assertEquals("Failed to convert path to artifact!", "1", artifact31.getVersion());
+        assertNull("Failed to convert path to artifact!", artifact31.getClassifier());
+        assertNull("Failed to covert path to artifact!", artifact31.getType());
     }
 
     @Test


### PR DESCRIPTION
This fixes a corner case and properly matches "versions" which are only digits (without any dots, i.e. `1`). 